### PR TITLE
Bugfix: Remove default limit for this geography endpoint

### DIFF
--- a/assets/js/components/indicators.js
+++ b/assets/js/components/indicators.js
@@ -269,7 +269,7 @@ export class IndicatorSection {
         url: '/api/geography/geography/'
       });
 
-      var activeMunicipalities = response.results.filter(function( obj ) {
+      var activeMunicipalities = response.filter(function( obj ) {
           return obj.is_disestablished !== true;
       });
       const miifGrouped  = _.groupBy(activeMunicipalities, "miif_category");

--- a/scorecard/views.py
+++ b/scorecard/views.py
@@ -26,6 +26,7 @@ from django.conf import settings
 class GeographyViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = models.Geography.objects.all()
     serializer_class = serializers.GeographySerializer
+    paginator = None
 
 
 class MunicipalityProfileViewSet(viewsets.ReadOnlyModelViewSet):


### PR DESCRIPTION
Remove default limit for this geography endpoint by setting paginator to None and update the api call response in indicator.js 