### PR TITLE
Fix capital expenditure calculation on v2 cube data

### DIFF
--- a/scorecard/profile_data/api_data.py
+++ b/scorecard/profile_data/api_data.py
@@ -391,6 +391,7 @@ class ApiData(object):
                 "cube": "capital_v2",
                 "aggregate": "amount.sum",
                 "cut": {
+                    "capital_type.code": ["NEW", "RENEWAL", "UPGRADING"],
                     "amount_type.code": ["AUDA"],
                     "demarcation.code": [self.geo_code],
                     "period_length.length": ["year"],
@@ -405,6 +406,7 @@ class ApiData(object):
                 "cube": "capital_v2",
                 "aggregate": "amount.sum",
                 "cut": {
+                    "capital_type.code": ["NEW", "RENEWAL", "UPGRADING"],
                     "amount_type.code": ["ADJB"],
                     "demarcation.code": [self.geo_code],
                     "period_length.length": ["year"],

--- a/scorecard/profile_data/indicators/capital_budget_spending.py
+++ b/scorecard/profile_data/indicators/capital_budget_spending.py
@@ -3,7 +3,7 @@ from .series import SeriesIndicator
 from .utils import (
     group_by_year,
     populate_periods,
-    filter_for_all_keys,
+    filter_for_all_keys_versioned,
     percent,
 )
 
@@ -73,12 +73,14 @@ class CapitalBudgetSpending(SeriesIndicator):
                 "result": result,
                 "overunder": "under" if result < 0 else "over",
                 "rating": cls.determine_rating(result),
+                "cube_version": values["cube_version"],
             })
         else:
             data.update({
                 "result": None,
                 "overunder": None,
                 "rating": None,
+                "cube_version": None,
             })
         return data
 
@@ -92,7 +94,7 @@ class CapitalBudgetSpending(SeriesIndicator):
                 results["capital_expenditure_budget_v1"],
                 "total_assets",
             ),
-            "budget",
+            ("budget", "v1"),
         )
         populate_periods(
             periods,
@@ -100,21 +102,21 @@ class CapitalBudgetSpending(SeriesIndicator):
                 results["capital_expenditure_actual_v1"],
                 "total_assets",
             ),
-            "actual",
+            ("actual", "v1"),
         )
         # Populate periods with v2 data
         populate_periods(
             periods,
             group_by_year(results["capital_expenditure_budget_v2"]),
-            "budget",
+            ("budget", "v2"),
         )
         populate_periods(
             periods,
             group_by_year(results["capital_expenditure_actual_v2"]),
-            "actual",
+            ("actual", "v2"),
         )
         # Filter out periods that don't have all the required data
-        periods = filter_for_all_keys(periods, [
+        periods = filter_for_all_keys_versioned(periods, [
             "budget", "actual",
         ])
         # Convert periods into dictionary

--- a/scorecard/profile_data/indicators/capital_budget_spending.py
+++ b/scorecard/profile_data/indicators/capital_budget_spending.py
@@ -22,11 +22,11 @@ class CapitalBudgetSpending(SeriesIndicator):
     formula = {
         "text": "= ((Actual Capital Expenditure - Budgeted Capital Expenditure) / Budgeted Capital Expenditure) * 100",
         "actual": [
-            "=", 
+            "=",
             "(",
             "(",
             {
-                "cube": "captial",
+                "cube": "capital",
                 "item_codes": ["4100"],
                 "amount_type": "AUDA",
             },

--- a/scorecard/profile_data/indicators/utils.py
+++ b/scorecard/profile_data/indicators/utils.py
@@ -97,9 +97,12 @@ def group_quarters(periods, select):
 
 
 def item_has_keys(item, keys):
-    _, values = item
+    year, values = item
+    def f(result, key):
+        print(f"result={result} key={key} year={year} values={values}")
+        return (result and (values.get(key) != None))
     return reduce(
-        lambda result, key: (result and (values.get(key) != None)),
+        f,
         keys,
         True
     )
@@ -110,6 +113,20 @@ def filter_for_all_keys(obj, keys):
         lambda item: item_has_keys(item, keys),
         obj.items()
     )
+
+
+def filter_for_all_keys_versioned(obj, keys):
+    result = list()
+    for year, values_dict in obj.items():
+        if all((k, "v2") in values_dict for k in keys):
+            unversioned_dict = {k: values_dict[(k, "v2")] for k in keys}
+            unversioned_dict["cube_version"] = "v2"
+            result.extend([(year, unversioned_dict)])
+        elif all((k, "v1") in values_dict for k in keys):
+            unversioned_dict = {k: values_dict[(k, "v1")] for k in keys}
+            unversioned_dict["cube_version"] = "v1"
+            result.extend([(year, unversioned_dict)])
+    return result
 
 
 def year_amount_key(result):

--- a/scorecard/tests/indicators/__init__.py
+++ b/scorecard/tests/indicators/__init__.py
@@ -27,6 +27,7 @@ def import_data(resource, filename):
 )
 class _IndicatorTestCase(TransactionTestCase):
     serialized_rollback = True
+    maxDiff = None
 
     def setUp(self):
         # Setup the API client

--- a/scorecard/tests/indicators/test_capital_budget_spending.py
+++ b/scorecard/tests/indicators/test_capital_budget_spending.py
@@ -168,27 +168,31 @@ class TestCapitalBudgetSpendingQueryAndCalculator(_IndicatorTestCase):
                 "values": [
                     {
                         "date": 2019,
-                        "result": 11.73,
-                        "overunder": "over",
-                        "rating": "ave"
+                        "result": -19.49,
+                        "overunder": "under",
+                        "rating": "bad",
+                        "cube_version": "v1",
                     },
                     {
                         "date": 2018,
-                        "result": -35.51,
+                        "result": -27.2,
                         "overunder": "under",
-                        "rating": "bad"
+                        "rating": "bad",
+                        "cube_version": "v1",
                     },
                     {
                         "date": 2017,
                         "result": -7.37,
                         "overunder": "under",
-                        "rating": "ave"
+                        "rating": "ave",
+                        "cube_version": "v1",
                     },
                     {
                         "date": 2016,
                         "result": -11.46,
                         "overunder": "under",
-                        "rating": "ave"
+                        "rating": "ave",
+                        "cube_version": "v1",
                     }
                 ],
                 "ref": {

--- a/scorecard/tests/indicators/test_capital_budget_spending.py
+++ b/scorecard/tests/indicators/test_capital_budget_spending.py
@@ -38,54 +38,38 @@ class CalculatorTests(SimpleTestCase):
             {
                 "capital_expenditure_budget_v1": [
                     {
-                        "amount_type.code": "AUDA",
                         "financial_year_end.year": 2040,
                         "total_assets.sum": 3,
-                        "item.code": "4200",
                     },
                     {
-                        "amount_type.code": "AUDA",
                         "financial_year_end.year": 2041,
                         "total_assets.sum": 4,
-                        "item.code": "4200",
                     },
                     {
-                        "amount_type.code": "AUDA",
                         "financial_year_end.year": 2042,
                         "total_assets.sum": 5,
-                        "item.code": "4200",
                     },
                     {
-                        "amount_type.code": "AUDA",
                         "financial_year_end.year": 2043,
                         "total_assets.sum": 6,
-                        "item.code": "4200",
                     },
                 ],
                 "capital_expenditure_actual_v1": [
                     {
-                        "amount_type.code": "AUDA",
                         "financial_year_end.year": 2040,
                         "total_assets.sum": 2,
-                        "item.code": "4200",
                     },
                     {
-                        "amount_type.code": "AUDA",
                         "financial_year_end.year": 2041,
                         "total_assets.sum": 8,
-                        "item.code": "4200",
                     },
                     {
-                        "amount_type.code": "AUDA",
                         "financial_year_end.year": 2042,
                         "total_assets.sum": 5,
-                        "item.code": "4200",
                     },
                     {
-                        "amount_type.code": "AUDA",
                         "financial_year_end.year": 2043,
                         "total_assets.sum": 6.6,
-                        "item.code": "4200",
                     },
                 ],
                 "capital_expenditure_budget_v2": [],
@@ -101,6 +85,61 @@ class CalculatorTests(SimpleTestCase):
              {'date': 2043, 'overunder': 'over', 'rating': 'ave', 'result': 10.0}],
             result["values"],
         )
+
+    def test_v2(self):
+        """ percentages and ratings are calculated correctly """
+        api_data = MockAPIData(
+            {
+                "capital_expenditure_budget_v1": [],
+                "capital_expenditure_actual_v1": [],
+                "capital_expenditure_budget_v2": [
+                    {
+                        "financial_year_end.year": 2040,
+                        "amount.sum": 3,
+                    },
+                    {
+                        "financial_year_end.year": 2041,
+                        "amount.sum": 4,
+                    },
+                    {
+                        "financial_year_end.year": 2042,
+                        "amount.sum": 5,
+                    },
+                    {
+                        "financial_year_end.year": 2043,
+                        "amount.sum": 6,
+                    },
+                ],
+                "capital_expenditure_actual_v2": [
+                    {
+                        "financial_year_end.year": 2040,
+                        "amount.sum": 2,
+                    },
+                    {
+                        "financial_year_end.year": 2041,
+                        "amount.sum": 8,
+                    },
+                    {
+                        "financial_year_end.year": 2042,
+                        "amount.sum": 5,
+                    },
+                    {
+                        "financial_year_end.year": 2043,
+                        "amount.sum": 6.6,
+                    },
+                ],
+            },
+            2040,
+        )
+        result = CapitalBudgetSpending.get_muni_specifics(api_data)
+        self.assertEqual(
+            [{'date': 2040, 'overunder': 'under', 'rating': 'bad', 'result': -33.33},
+             {'date': 2041, 'overunder': 'over', 'rating': 'bad', 'result': 100.0},
+             {'date': 2042, 'overunder': 'over', 'rating': 'good', 'result': 0.0},
+             {'date': 2043, 'overunder': 'over', 'rating': 'ave', 'result': 10.0}],
+            result["values"],
+        )
+
 
 
 class TestCapitalBudgetSpendingQueryAndCalculator(_IndicatorTestCase):

--- a/scorecard/tests/indicators/test_capital_budget_spending.py
+++ b/scorecard/tests/indicators/test_capital_budget_spending.py
@@ -56,10 +56,10 @@ class CalculatorTests(SimpleTestCase):
         )
         result = CapitalBudgetSpending.get_muni_specifics(api_data)
         self.assertEqual(
-            [{'date': 2040, 'overunder': 'under', 'rating': 'bad', 'result': -33.33},
-             {'date': 2041, 'overunder': 'over', 'rating': 'bad', 'result': 100.0},
-             {'date': 2042, 'overunder': 'over', 'rating': 'good', 'result': 0.0},
-             {'date': 2043, 'overunder': 'over', 'rating': 'ave', 'result': 10.0}],
+            [{'date': 2040, 'overunder': 'under', 'rating': 'bad', 'result': -33.33, "cube_version": "v1" },
+             {'date': 2041, 'overunder': 'over', 'rating': 'bad', 'result': 100.0, "cube_version": "v1" },
+             {'date': 2042, 'overunder': 'over', 'rating': 'good', 'result': 0.0, "cube_version": "v1" },
+             {'date': 2043, 'overunder': 'over', 'rating': 'ave', 'result': 10.0, "cube_version": "v1" }],
             result["values"],
         )
 
@@ -86,10 +86,10 @@ class CalculatorTests(SimpleTestCase):
         )
         result = CapitalBudgetSpending.get_muni_specifics(api_data)
         self.assertEqual(
-            [{'date': 2040, 'overunder': 'under', 'rating': 'bad', 'result': -33.33},
-             {'date': 2041, 'overunder': 'over', 'rating': 'bad', 'result': 100.0},
-             {'date': 2042, 'overunder': 'over', 'rating': 'good', 'result': 0.0},
-             {'date': 2043, 'overunder': 'over', 'rating': 'ave', 'result': 10.0}],
+            [{'date': 2040, 'overunder': 'under', 'rating': 'bad', 'result': -33.33, "cube_version": "v2" },
+             {'date': 2041, 'overunder': 'over', 'rating': 'bad', 'result': 100.0, "cube_version": "v2" },
+             {'date': 2042, 'overunder': 'over', 'rating': 'good', 'result': 0.0, "cube_version": "v2" },
+             {'date': 2043, 'overunder': 'over', 'rating': 'ave', 'result': 10.0, "cube_version": "v2" }],
             result["values"],
         )
 
@@ -126,10 +126,10 @@ class CalculatorTests(SimpleTestCase):
         )
         result = CapitalBudgetSpending.get_muni_specifics(api_data)
         self.assertEqual(
-            [{'date': 2040, 'overunder': 'over', 'rating': 'good', 'result': 0.0},
-             {'date': 2041, 'overunder': 'under', 'rating': 'ave', 'result': -10.0},
-             {'date': 2042, 'overunder': 'under', 'rating': 'bad', 'result': -20.0},
-             {'date': 2043, 'overunder': None, 'rating': None, 'result': None}],
+            [{'date': 2040, 'overunder': 'over', 'rating': 'good', 'result': 0.0, "cube_version": "v2" },
+             {'date': 2041, 'overunder': 'under', 'rating': 'ave', 'result': -10.0, "cube_version": "v1" },
+             {'date': 2042, 'overunder': 'under', 'rating': 'bad', 'result': -20.0, "cube_version": "v1" },
+             {'date': 2043, 'overunder': None, 'rating': None, 'result': None, "cube_version": None }],
             result["values"],
         )
 

--- a/scorecard/tests/indicators/test_capital_budget_spending.py
+++ b/scorecard/tests/indicators/test_capital_budget_spending.py
@@ -37,39 +37,16 @@ class CalculatorTests(SimpleTestCase):
         api_data = MockAPIData(
             {
                 "capital_expenditure_budget_v1": [
-                    {
-                        "financial_year_end.year": 2040,
-                        "total_assets.sum": 3,
-                    },
-                    {
-                        "financial_year_end.year": 2041,
-                        "total_assets.sum": 4,
-                    },
-                    {
-                        "financial_year_end.year": 2042,
-                        "total_assets.sum": 5,
-                    },
-                    {
-                        "financial_year_end.year": 2043,
-                        "total_assets.sum": 6,
-                    },
+                    { "financial_year_end.year": 2040, "total_assets.sum": 3, },
+                    { "financial_year_end.year": 2041, "total_assets.sum": 4, },
+                    { "financial_year_end.year": 2042, "total_assets.sum": 5, },
+                    { "financial_year_end.year": 2043, "total_assets.sum": 6, },
                 ],
                 "capital_expenditure_actual_v1": [
-                    {
-                        "financial_year_end.year": 2040,
-                        "total_assets.sum": 2,
-                    },
-                    {
-                        "financial_year_end.year": 2041,
-                        "total_assets.sum": 8,
-                    },
-                    {
-                        "financial_year_end.year": 2042,
-                        "total_assets.sum": 5,
-                    },
-                    {
-                        "financial_year_end.year": 2043,
-                        "total_assets.sum": 6.6,
+                    { "financial_year_end.year": 2040, "total_assets.sum": 2, },
+                    { "financial_year_end.year": 2041, "total_assets.sum": 8, },
+                    { "financial_year_end.year": 2042, "total_assets.sum": 5, },
+                    { "financial_year_end.year": 2043, "total_assets.sum": 6.6,
                     },
                 ],
                 "capital_expenditure_budget_v2": [],
@@ -93,40 +70,16 @@ class CalculatorTests(SimpleTestCase):
                 "capital_expenditure_budget_v1": [],
                 "capital_expenditure_actual_v1": [],
                 "capital_expenditure_budget_v2": [
-                    {
-                        "financial_year_end.year": 2040,
-                        "amount.sum": 3,
-                    },
-                    {
-                        "financial_year_end.year": 2041,
-                        "amount.sum": 4,
-                    },
-                    {
-                        "financial_year_end.year": 2042,
-                        "amount.sum": 5,
-                    },
-                    {
-                        "financial_year_end.year": 2043,
-                        "amount.sum": 6,
-                    },
+                    { "financial_year_end.year": 2040, "amount.sum": 3, },
+                    { "financial_year_end.year": 2041, "amount.sum": 4, },
+                    { "financial_year_end.year": 2042, "amount.sum": 5, },
+                    { "financial_year_end.year": 2043, "amount.sum": 6, },
                 ],
                 "capital_expenditure_actual_v2": [
-                    {
-                        "financial_year_end.year": 2040,
-                        "amount.sum": 2,
-                    },
-                    {
-                        "financial_year_end.year": 2041,
-                        "amount.sum": 8,
-                    },
-                    {
-                        "financial_year_end.year": 2042,
-                        "amount.sum": 5,
-                    },
-                    {
-                        "financial_year_end.year": 2043,
-                        "amount.sum": 6.6,
-                    },
+                    { "financial_year_end.year": 2040, "amount.sum": 2, },
+                    { "financial_year_end.year": 2041, "amount.sum": 8, },
+                    { "financial_year_end.year": 2042, "amount.sum": 5, },
+                    { "financial_year_end.year": 2043, "amount.sum": 6.6, },
                 ],
             },
             2040,
@@ -137,6 +90,46 @@ class CalculatorTests(SimpleTestCase):
              {'date': 2041, 'overunder': 'over', 'rating': 'bad', 'result': 100.0},
              {'date': 2042, 'overunder': 'over', 'rating': 'good', 'result': 0.0},
              {'date': 2043, 'overunder': 'over', 'rating': 'ave', 'result': 10.0}],
+            result["values"],
+        )
+
+    def test_v1_v2(self):
+        """
+        - v2 is used when budget and actual data is available
+        - v1 is used when availabel and there isn't both budget and actual
+          available from v2
+           - 2040 v2 was available for both, v1 was not available
+           - 2041 v2 was only available for budget, v1 was available
+           - 2042 v2 was only available for actual, v1 was available
+           - 2043 neither v1 nor v2 was available
+        """
+        api_data = MockAPIData(
+            {
+                "capital_expenditure_budget_v1": [
+                    { "financial_year_end.year": 2041, "total_assets.sum": 1, },
+                    { "financial_year_end.year": 2042, "total_assets.sum": 1, },
+                ],
+                "capital_expenditure_actual_v1": [
+                    { "financial_year_end.year": 2041, "total_assets.sum": 0.9, },
+                    { "financial_year_end.year": 2042, "total_assets.sum": 0.8, },
+                ],
+                "capital_expenditure_budget_v2": [
+                    { "financial_year_end.year": 2040, "amount.sum": 1, },
+                    { "financial_year_end.year": 2041, "amount.sum": 0.8, },
+                ],
+                "capital_expenditure_actual_v2": [
+                    { "financial_year_end.year": 2040, "amount.sum": 1, },
+                    { "financial_year_end.year": 2042, "amount.sum": 1.2, },
+                ],
+            },
+            2040,
+        )
+        result = CapitalBudgetSpending.get_muni_specifics(api_data)
+        self.assertEqual(
+            [{'date': 2040, 'overunder': 'over', 'rating': 'good', 'result': 0.0},
+             {'date': 2041, 'overunder': 'under', 'rating': 'ave', 'result': -10.0},
+             {'date': 2042, 'overunder': 'under', 'rating': 'bad', 'result': -20.0},
+             {'date': 2043, 'overunder': None, 'rating': None, 'result': None}],
             result["values"],
         )
 

--- a/scorecard/tests/indicators/test_uifw_expenditure.py
+++ b/scorecard/tests/indicators/test_uifw_expenditure.py
@@ -79,10 +79,10 @@ class TestUIFWExpenditure(_IndicatorTestCase):
                 "formula": {
                     "text": "= (Unauthorised, Irregular, Fruitless and Wasteful Expenditure / Actual Operating Expenditure) * 100",
                     "actual": [
-                        "=", 
-                        "(", 
+                        "=",
+                        "(",
                         {
-                            "cube": "uifw",
+                            "cube": "uifwexp",
                             "item_codes": ["irregular", "fruitless", "unauthorised"],
                         },
                         "/",
@@ -91,7 +91,7 @@ class TestUIFWExpenditure(_IndicatorTestCase):
                             "item_codes": ["4600"],
                             "amount_type": "AUDA",
                         },
-                        ")", 
+                        ")",
                         "*",
                         "100",
                     ],


### PR DESCRIPTION
- filter v2 capital expenditure query to only new, upgrading and renewal
- don't mix v1 and v2 data for capital expenditure calculation - other indicators still need this fix