### PR TITLE
Remove PDF files from URLs serving with http only

### DIFF
--- a/assets/js/components/audit-opinions.js
+++ b/assets/js/components/audit-opinions.js
@@ -19,6 +19,11 @@ class ReportCard {
     logIfUnequal(1, this.$element.length);
     this.$element.find(".audit-outcome__year").text(formatFinancialYear(report.date));
     this.$element.find(".audit-outcome__heading").text(report.result);
+
+    if (report.report_url.endsWith('.pdf')) {
+      report.report_url = report.report_url.substring(0, report.report_url.lastIndexOf("/"));
+    }
+
     this.$element.find(".audit-outcome__download").attr("href", report.report_url);
     if (report.report_url === null) {
       this.$element.find(".audit-outcome__download").text("No report available");


### PR DESCRIPTION
Issue: https://trello.com/c/zkpTAAWK/316-audit-report-links-dont-open-the-pdf-in-chrome