### PR TITLE
Add notice to capex v2 page on the data explorer

### DIFF
--- a/municipal_finance/static/javascript/table.js
+++ b/municipal_finance/static/javascript/table.js
@@ -955,7 +955,9 @@
   });
 
   if ($("#table-view > div.container-fluid > header > h2").text() == "Capital Acquisition (v2)" ) {
-    $("#table-view > div.container-fluid > section").text("Coming soon");
+    $(".table-display").prepend("Coming soon");
+    $(".row-headings").hide();
+    $(".table-scroll-area").hide();
   }
 
   exports.view = new MainView();

--- a/municipal_finance/static/javascript/table.js
+++ b/municipal_finance/static/javascript/table.js
@@ -954,5 +954,9 @@
     },
   });
 
+  if ($("#table-view > div.container-fluid > header > h2").text() == "Capital Acquisition (v2)" ) {
+    $("#table-view > div.container-fluid > section").text("Coming soon");
+  }
+
   exports.view = new MainView();
 })(window);


### PR DESCRIPTION
Issue: https://trello.com/c/nBtl0CWe/515-dont-show-capex-v2-table-to-users-while-its-aggregating-stuff-it-shouldnt

![image](https://user-images.githubusercontent.com/9511724/161601414-4612e16d-c78a-46cc-92ae-54b167e42f05.png)
