### PR TITLE
Hide formula elements only for an indicators corresponding latest_year

### DIFF
--- a/assets/js/components/indicators.js
+++ b/assets/js/components/indicators.js
@@ -93,12 +93,12 @@ export class IndicatorSection {
 
     // Hide unused formula elements
     if (this.sectionData.last_year <= 2019){
-      $(".is--post-2019-20").hide()
-      $(".indicator-calculation__heading").hide()
+      this.$element.find(".is--post-2019-20").hide();
+      this.$element.find(".indicator-calculation__heading").hide();
     }
     if (this.sectionData.last_year >= 2023){
-      $(".is--pre-2019-20").hide()
-      $(".indicator-calculation__heading").hide()
+      this.$element.find(".is--pre-2019-20").hide();
+      this.$element.find(".indicator-calculation__heading").hide();
     }
 
     if (formulaDataV2) {


### PR DESCRIPTION
Related issue: https://trello.com/c/dJaVjMse/514-upload-latest-financial-performance-data-update