### PR TITLE
Add report_url to audit opinion facts

### DIFF
--- a/municipal_finance/fixtures/tests/update/audit_opinion_facts/insert.csv
+++ b/municipal_finance/fixtures/tests/update/audit_opinion_facts/insert.csv
@@ -1,2 +1,2 @@
-demarcation_code,year,opinion_code,opinion_label
-CPT,2019,unqualified_emphasis_of_matter,Unqualified - Emphasis of Matter items
+demarcation_code,year,opinion_code,opinion_label,report_url
+CPT,2019,unqualified_emphasis_of_matter,Unqualified - Emphasis of Matter items,

--- a/municipal_finance/fixtures/tests/update/audit_opinion_facts/update.csv
+++ b/municipal_finance/fixtures/tests/update/audit_opinion_facts/update.csv
@@ -1,3 +1,3 @@
-demarcation_code,year,opinion_code,opinion_label
-CPT,2018,unqualified_emphasis_of_matter,Unqualified - Emphasis of Matter items
-CPT,2019,unqualified_emphasis_of_matter,Unqualified - Emphasis of Matter items
+demarcation_code,year,opinion_code,opinion_label,report_url
+CPT,2018,unqualified_emphasis_of_matter,Unqualified - Emphasis of Matter items,
+CPT,2019,unqualified_emphasis_of_matter,Unqualified - Emphasis of Matter items,

--- a/municipal_finance/tests/update/test_audit_opinion_facts.py
+++ b/municipal_finance/tests/update/test_audit_opinion_facts.py
@@ -57,3 +57,17 @@ class UpdateAuditOpinionFacts(TransactionTestCase):
         self.assertEqual(AuditOpinionFacts.objects.all().count(), 4)
         self.assertEqual(self.update_obj.deleted, 1)
         self.assertEqual(self.update_obj.inserted, 2)
+
+    def test_report_url(self):
+        self.assertEqual(
+            AuditOpinionFacts.objects.get(demarcation_code="CPT", financial_year="2018").report_url,
+            "http://mfma.treasury.gov.za/Documents/07.%20Audit%20Reports/2017-18/01.%20Metros/CPT%20Cape%20Town/CPT%20Cape%20Town%20Audit%20Report%202017-18.pdf"
+        )
+        update_audit_opinion_facts(
+            self.insert_obj,
+            batch_size=4,
+        )
+        self.assertEqual(
+            AuditOpinionFacts.objects.get(demarcation_code="CPT", financial_year="2019").report_url,
+            ""
+        )

--- a/municipal_finance/update/audit_opinion_facts.py
+++ b/municipal_finance/update/audit_opinion_facts.py
@@ -19,6 +19,7 @@ AuditOpinionFactRow = namedtuple(
         "financial_year",
         "opinion_code",
         "opinion_label",
+        "report_url",
     ),
 )
 
@@ -47,6 +48,7 @@ class AuditOpinionFactsUpdater(Updater):
             financial_year=row.financial_year,
             opinion_code=row.opinion_code,
             opinion_label=row.opinion_label,
+            report_url=row.report_url,
         )
 
 


### PR DESCRIPTION
Issue: https://trello.com/c/MdwRsxXZ/517-add-support-for-audit-report-url-to-audit-opinion-facts-update-est-1-day