### PR TITLE
Use falsy to check that audit report URL is not available

### DIFF
--- a/assets/js/components/audit-opinions.js
+++ b/assets/js/components/audit-opinions.js
@@ -21,7 +21,7 @@ class ReportCard {
     this.$element.find(".audit-outcome__heading").text(report.result);
 
     let reportURL = report.report_url;
-    if (reportURL === null) {
+    if (!reportURL) {
       this.$element.find(".audit-outcome__download").text("No report available");
     }
     else if (!reportURL.startsWith('https') && reportURL.endsWith('.pdf')) {


### PR DESCRIPTION
Issue: https://trello.com/c/t7OBk8r4/545-verify-treasurys-audit-opinion-report-files