### PR TITLE
Add site notices to data explorer

### DIFF
--- a/municipal_finance/static/stylesheets/docs.scss
+++ b/municipal_finance/static/stylesheets/docs.scss
@@ -1,3 +1,7 @@
+.site-notice {
+  padding: 1px 28px;
+}
+
 .tocify-wrapper {
   img.logo {
     width: 100%;

--- a/municipal_finance/static/stylesheets/site.scss
+++ b/municipal_finance/static/stylesheets/site.scss
@@ -23,6 +23,10 @@ $black: #333;
   }
 }
 
+.site-notice {
+  padding: 10px 15px 1px;
+}
+
 .jumbotron {
   .logo {
     height: 80px;

--- a/municipal_finance/static/stylesheets/table.scss
+++ b/municipal_finance/static/stylesheets/table.scss
@@ -53,6 +53,16 @@ label {
     }
   }
 
+  h3 {
+    margin: -1px 0px 0px 140px;
+    font-size: 14px;
+    color: white;
+
+    a {
+      color: white;
+    }
+  }
+
   .logo {
     position: absolute;
     height: 53px;

--- a/municipal_finance/static/stylesheets/table.scss
+++ b/municipal_finance/static/stylesheets/table.scss
@@ -54,7 +54,7 @@ label {
   }
   h1.site-notice {
     margin: -1px 0px 0px 140px;
-    font-size: 14px;
+    font-size: 16px;
     color: white;
 
     a {
@@ -86,6 +86,11 @@ label {
       }
     }
   }
+}
+
+.site-notice {
+  margin: 1px 0px -10px 140px;
+  font-size: 12px;
 }
 
 #spinner {

--- a/municipal_finance/static/stylesheets/table.scss
+++ b/municipal_finance/static/stylesheets/table.scss
@@ -52,8 +52,7 @@ label {
       color: white;
     }
   }
-
-  h3 {
+  h1.site-notice {
     margin: -1px 0px 0px 140px;
     font-size: 14px;
     color: white;

--- a/municipal_finance/templates/docs.html
+++ b/municipal_finance/templates/docs.html
@@ -34,8 +34,8 @@
 
 <div class="page-wrapper">
   <div class="content">
-    {% for notice in site_notices %}<h3>{{ notice.content | safe }}</h3>{% endfor %}
     <h1 id="intro">Municipal Money API Documentation</h1>
+    {% for notice in site_notices %}<div class="site-notice">{{ notice.content | safe }}</div>{% endfor %}
     <aside class="info">
       Usage of this data is subject to the <b><a href="/terms">Terms of Use</a></b>
     </aside>

--- a/municipal_finance/templates/docs.html
+++ b/municipal_finance/templates/docs.html
@@ -34,6 +34,7 @@
 
 <div class="page-wrapper">
   <div class="content">
+    {% for notice in site_notices %}<h3>{{ notice.content | safe }}</h3>{% endfor %}
     <h1 id="intro">Municipal Money API Documentation</h1>
     <aside class="info">
       Usage of this data is subject to the <b><a href="/terms">Terms of Use</a></b>

--- a/municipal_finance/templates/layout.html
+++ b/municipal_finance/templates/layout.html
@@ -9,6 +9,7 @@
     <meta name="csrf-token" content="{{ csrf_token }}">
     <meta name="google-site-verification" content="wGl9Jd3oxgnbklAbePVsucACMR8g38SXoSq6hvyb9Gk" />
     <meta name="msvalidate.01" content="302E91E15E0652704A4BAA3FF1F134D3" />
+    {% if NO_INDEX %}<meta name="robots" content="noindex">{% endif %}
     
     {% block head-css %}
     {% endblock %}

--- a/municipal_finance/templates/layout_data.html
+++ b/municipal_finance/templates/layout_data.html
@@ -16,8 +16,9 @@
     <h1><a href="/">Municipal Finance Data</a></h1>
   </div>
 </header>
-{% for notice in site_notices %}<h4>{{ notice.content | safe }}</h4>{% endfor %}
-
+<div class="container site-notice">
+  {% for notice in site_notices %}<div>{{ notice.content | safe }}</div>{% endfor %}
+</div>
 {% block page-content %}
 {% endblock %}
 

--- a/municipal_finance/templates/layout_data.html
+++ b/municipal_finance/templates/layout_data.html
@@ -16,6 +16,7 @@
     <h1><a href="/">Municipal Finance Data</a></h1>
   </div>
 </header>
+{% for notice in site_notices %}<h4>{{ notice.content | safe }}</h4>{% endfor %}
 
 {% block page-content %}
 {% endblock %}

--- a/municipal_finance/templates/table.html
+++ b/municipal_finance/templates/table.html
@@ -24,8 +24,9 @@
 
     <img src="{% static 'images/treasury-logo.png' %}" class="logo">
     {% if site_notices %}
-      <h3><a href="/">Municipal Finance Data Tables</a></h3>
-      {% for notice in site_notices %}<h3>{{ notice.content | safe }}</h3>{% endfor %}
+        <h1 class="site-notice"><a href="/">Municipal Finance Data Tables</a></h1>
+        {% for notice in site_notices %}<h1 class="site-notice">{{ notice.content | safe }}</h1>{% endfor %}
+
     {% else %}
       <h1><a href="/">Municipal Finance Data Tables</a></h1>
     {% endif %}

--- a/municipal_finance/templates/table.html
+++ b/municipal_finance/templates/table.html
@@ -25,7 +25,7 @@
     <img src="{% static 'images/treasury-logo.png' %}" class="logo">
     {% if site_notices %}
         <h1 class="site-notice"><a href="/">Municipal Finance Data Tables</a></h1>
-        {% for notice in site_notices %}<h1 class="site-notice">{{ notice.content | safe }}</h1>{% endfor %}
+        {% for notice in site_notices %}<div class="site-notice">{{ notice.content | safe }}</div>{% endfor %}
 
     {% else %}
       <h1><a href="/">Municipal Finance Data Tables</a></h1>

--- a/municipal_finance/templates/table.html
+++ b/municipal_finance/templates/table.html
@@ -23,11 +23,15 @@
     </div>
 
     <img src="{% static 'images/treasury-logo.png' %}" class="logo">
-    <h1><a href="/">Municipal Finance Data Tables</a></h1>
+    {% if site_notices %}
+      <h3><a href="/">Municipal Finance Data Tables</a></h3>
+      {% for notice in site_notices %}<h3>{{ notice.content | safe }}</h3>{% endfor %}
+    {% else %}
+      <h1><a href="/">Municipal Finance Data Tables</a></h1>
+    {% endif %}
   </div>
   <div id="spinner" class="progress-bar progress-bar-striped active"></div>
 </header>
-{% for notice in site_notices %}<h4>{{ notice.content | safe }}</h4>{% endfor %}
 
 <article id="table-view">
   <div class="container-fluid">

--- a/municipal_finance/templates/table.html
+++ b/municipal_finance/templates/table.html
@@ -27,6 +27,7 @@
   </div>
   <div id="spinner" class="progress-bar progress-bar-striped active"></div>
 </header>
+{% for notice in site_notices %}<h4>{{ notice.content | safe }}</h4>{% endfor %}
 
 <article id="table-view">
   <div class="container-fluid">


### PR DESCRIPTION
Issue: https://trello.com/c/cOcFTbQS/525-show-site-notices-on-data-explorer-site-incl-docs-so-that-users-who-somehow-land-there-know-that-it-isnt-official-data-est-1d