### PR TITLE
Add more financial years to infra demo data

### DIFF
--- a/infra-demo-data.json
+++ b/infra-demo-data.json
@@ -240,6 +240,136 @@
         }
     },
     {
+        "model": "infrastructure.expenditure",
+        "pk": 38,
+        "fields": {
+            "project": 1,
+            "budget_phase": 27,
+            "financial_year": 5,
+            "amount": "9985125.00"
+        }
+    },
+    {
+        "model": "infrastructure.expenditure",
+        "pk": 39,
+        "fields": {
+            "project": 1,
+            "budget_phase": 27,
+            "financial_year": 6,
+            "amount": "7867300.00"
+        }
+    },
+    {
+        "model": "infrastructure.expenditure",
+        "pk": 40,
+        "fields": {
+            "project": 2,
+            "budget_phase": 27,
+            "financial_year": 5,
+            "amount": "22722530.00"
+        }
+    },
+    {
+        "model": "infrastructure.expenditure",
+        "pk": 41,
+        "fields": {
+            "project": 2,
+            "budget_phase": 27,
+            "financial_year": 6,
+            "amount": "20000000.00"
+        }
+    },
+    {
+        "model": "infrastructure.expenditure",
+        "pk": 42,
+        "fields": {
+            "project": 4,
+            "budget_phase": 25,
+            "financial_year": 4,
+            "amount": "69709.00"
+        }
+    },
+    {
+        "model": "infrastructure.expenditure",
+        "pk": 43,
+        "fields": {
+            "project": 4,
+            "budget_phase": 27,
+            "financial_year": 5,
+            "amount": "500000.00"
+        }
+    },
+    {
+        "model": "infrastructure.expenditure",
+        "pk": 44,
+        "fields": {
+            "project": 4,
+            "budget_phase": 27,
+            "financial_year": 6,
+            "amount": "500000.00"
+        }
+    },
+    {
+        "model": "infrastructure.expenditure",
+        "pk": 45,
+        "fields": {
+            "project": 5,
+            "budget_phase": 27,
+            "financial_year": 5,
+            "amount": "89500000.00"
+        }
+    },
+    {
+        "model": "infrastructure.expenditure",
+        "pk": 46,
+        "fields": {
+            "project": 5,
+            "budget_phase": 27,
+            "financial_year": 6,
+            "amount": "87500000.00"
+        }
+    },
+    {
+        "model": "infrastructure.expenditure",
+        "pk": 47,
+        "fields": {
+            "project": 6,
+            "budget_phase": 27,
+            "financial_year": 5,
+            "amount": "35000000.00"
+        }
+    },
+    {
+        "model": "infrastructure.expenditure",
+        "pk": 48,
+        "fields": {
+            "project": 6,
+            "budget_phase": 27,
+            "financial_year": 6,
+            "amount": "28000000.00"
+        }
+    },
+    {
+        "model": "infrastructure.expenditure",
+        "pk": 49,
+        "fields": {
+            "project": 7,
+            "budget_phase": 27,
+            "financial_year": 5,
+            "amount": "169346000.00"
+        }
+    },
+    {
+        "model": "infrastructure.expenditure",
+        "pk": 50,
+        "fields": {
+            "project": 7,
+            "budget_phase": 27,
+            "financial_year": 6,
+            "amount": "178060440.00"
+        }
+    },
+    {
         "model": "infrastructure.financialyear",
         "pk": 1,
         "fields": {
@@ -251,6 +381,27 @@
         "pk": 3,
         "fields": {
             "budget_year": "2018/2019"
+        }
+    },
+    {
+        "model": "infrastructure.financialyear",
+        "pk": 4,
+        "fields": {
+            "budget_year": "2017/2018"
+        }
+    },
+    {
+        "model": "infrastructure.financialyear",
+        "pk": 5,
+        "fields": {
+            "budget_year": "2020/2021"
+        }
+    },
+    {
+        "model": "infrastructure.financialyear",
+        "pk": 6,
+        "fields": {
+            "budget_year": "2021/2022"
         }
     },
     {


### PR DESCRIPTION
Issue: https://trello.com/c/s7gs3N9n/636-add-demo-dev-data-for-capital-projects-which-loads-in-heroku-automatically