### PR TITLE
Render household bill charts using partial data

### DIFF
--- a/assets/js/pages/profile.js
+++ b/assets/js/pages/profile.js
@@ -151,8 +151,7 @@ export default class ProfilePage {
     const householdPercent = pageData.household_percent;
 
     $('#income-over-time .indicator-metric').hide();
-
-    if (householdPercent.Middle) {
+    if (chartData) {
       $('#income-over-time .financial-period').empty();
       overall_chart($('#income-over-time .indicator-chart')[0], chartData);
 


### PR DESCRIPTION
Story: https://trello.com/c/5aErVWq0/731-household-bills-charts-are-not-showing-on-the-scorecard-after-the-2023-q4-update