### PR TITLE
Use constance to show the correct grants quarter

### DIFF
--- a/assets/js/components/income.js
+++ b/assets/js/components/income.js
@@ -341,13 +341,9 @@ export class NationalConditionalGrantsSection extends AbstractIncomeSection {
       this._transferredLabel = {};
       this._spentLabel = {};
       for (const year in this._chartData) {
-        const legendYear = this.sectionData.snapshot_date.year;
-        let legendQuarter = null;
-        if (year >= this.sectionData.snapshot_date.year) {
-          legendQuarter = this.sectionData.snapshot_date.quarter;
-        } else if (year < this.sectionData.snapshot_date.year) {
-          legendQuarter = 4;
-        }
+        let legendYear = this.sectionData.snapshot_date.year;
+        let legendQuarter = this.sectionData.snapshot_date.quarter;
+
         this._transferredLabel[year] = `Amount transferred up to ${legendYear} Q${legendQuarter}`;
         this._spentLabel[year] = `Amount spent up to ${legendYear} Q${legendQuarter}`;
 


### PR DESCRIPTION
Story: https://trello.com/c/rNClUXkX/772-grants-up-to-q2-have-been-added-but-the-scorecard-shows-q4